### PR TITLE
Document the debug hash value in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Breaking Changes!
 ## Usage
 
 * Visit `/_ping.php` to get a system status
-* By using `?debug=hash` additional status check table and time profiling information is displayed.
-  * See [Ping Development & Testing](#ping-development--testing) how to obtain the `hash` value.
+* By using `?debug=token` additional status check table and time profiling information is displayed.
+  * See [Ping Development & Testing](#ping-development--testing) how to obtain the `token` value.
 * Find slow checks and checks errors in logs.
 
 ## Checks
@@ -135,7 +135,7 @@ They have separate dirs.
 `_ping.php` can be accessed over the lando url.
 For example `http://localhost:51418/_ping.php`.
 It can also be accessed from the shell `cd /app/drupal9/web ; php _ping.php`.
-From the shell output the debug code can be attained.
+From the shell output the debug token can be attained.
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Breaking Changes!
 
 ## Usage
 
-* One can visit `/_ping.php` to get a status
-* By using `?debug=hash` query, one can get status check status table, and time profiling table. The `hash` is 4 first letters of the salt in `settings.php`.
+* Visit `/_ping.php` to get a system status
+* By using `?debug=hash` additional status check table and time profiling information is displayed.
+    * The `hash` is `md5` of `hash_salt` defined in Drupal `settings.php`.
 * Find slow checks and checks errors in logs.
 
 ## Checks

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Breaking Changes!
 
 * Visit `/_ping.php` to get a system status
 * By using `?debug=hash` additional status check table and time profiling information is displayed.
-    * The `hash` is `md5` of `hash_salt` defined in Drupal `settings.php`.
+  * See [Ping Development & Testing](#ping-development--testing) how to obtain the `hash` value.
 * Find slow checks and checks errors in logs.
 
 ## Checks

--- a/settings.php
+++ b/settings.php
@@ -51,7 +51,7 @@ $settings['ping_elasticsearch_connections'] = [
   ],
 ];
 
-// For debugging add "?debug=test" to the query - 4 letters of the hash.
+// In certain situations `hash_salt` is used to generate the debug token.
 $settings['hash_salt'] = 'testing';
 
 // @codingStandardsIgnoreLine DrupalPractice.Commenting.CommentEmptyLine.SpacingAfter


### PR DESCRIPTION
Document / refer how to obtain debug hash value in usage chapter and simplify the sentences of usage information.