### PR TITLE
reverts pull/35

### DIFF
--- a/_ping.php
+++ b/_ping.php
@@ -1204,7 +1204,7 @@ class FsSchemeCleanupChecker extends Checker {
     }
 
     if ($removed > 0) {
-      $this->setStatus('warning', 'Orphaned fs check files deleted.', [
+      $this->setStatus('errors', 'Orphaned fs check files deleted.', [
         'removed_count' => $removed,
       ]);
       return;


### PR DESCRIPTION
Issue: FS check file removal using glob breaks when multiple instances of _ping.php are ran concurrently.

I propose lowering the error level for this particular check  (reverts https://github.com/wunderio/drupal-ping/pull/35) as file creation already takes care of fs rw check and removal is done with the same user so it should succeed as well.