### PR TITLE
SchemeCleanup: Mtime: Check

### DIFF
--- a/_ping.php
+++ b/_ping.php
@@ -1070,10 +1070,11 @@ class FsSchemeCreateChecker extends Checker {
       return;
     }
     
-    for ($time = microtime(TRUE); microtime(TRUE) - $time < 1.0 && !file_exists($tmp); usleep(10000)) {}
+    $check_time = 1.0;
+    for ($time = microtime(TRUE); microtime(TRUE) - $check_time < 1.0 && !file_exists($tmp); usleep(10000)) {}
     
     if (!file_exists($tmp)) {
-      $this->setStatus('error', 'File did not appear during 1 sec.', [
+      $this->setStatus('warning', "File did not appear during $check_time sec.", [
         'file' => $tmp,
       ]);
       return;
@@ -1081,13 +1082,6 @@ class FsSchemeCreateChecker extends Checker {
 
     if (!touch($tmp)) {
       $this->setStatus('error', 'Could not touch file.', [
-        'file' => $tmp,
-      ]);
-      return;
-    }
-    
-    if (!file_exists($tmp)) {
-      $this->setStatus('error', 'File did not appear during 1 sec.', [
         'file' => $tmp,
       ]);
       return;

--- a/_ping.php
+++ b/_ping.php
@@ -1121,6 +1121,7 @@ class FsSchemeDeleteChecker extends Checker {
     if (!unlink($this->file)) {
       $this->setStatus('error', 'Could not delete newly created file in the files directory.', [
         'file' => $this->file,
+        'error' => error_get_last()['message'],
       ]);
       return;
     }

--- a/_ping.php
+++ b/_ping.php
@@ -1199,12 +1199,12 @@ class FsSchemeCleanupChecker extends Checker {
         $this->setStatus('error', 'Could not get mtime of the file in the public files directory.', [
           'file' => $file,
         ]);
-        return;
+        continue;
       }
 
       // Do not clean up fresh files.
       // In the multicontainer environment parallel pings would kill each other.
-      if ($mtime > time() - 3600) {
+      if ($mtime < time() - 3600) {
         continue;
       }
 

--- a/_ping.php
+++ b/_ping.php
@@ -1193,6 +1193,21 @@ class FsSchemeCleanupChecker extends Checker {
       if (filesize($file) !== 0) {
         continue;
       }
+
+      $mtime = filemtime($file);
+      if (!$mtime) {
+        $this->setStatus('error', 'Could not get mtime of the file in the public files directory.', [
+          'file' => $file,
+        ]);
+        return;
+      }
+
+      // Do not clean up fresh files.
+      // In the multicontainer environment parallel pings would kill each other.
+      if ($mtime > time() - 3600) {
+        continue;
+      }
+
       // @codingStandardsIgnoreLine PHPCS_SecurityAudit.BadFunctions.FilesystemFunctions.WarnFilesystem
       if (!unlink($file)) {
         $this->setStatus('error', 'Could not delete file in the public files directory.', [

--- a/_ping.php
+++ b/_ping.php
@@ -1080,17 +1080,17 @@ class FsSchemeCreateChecker extends Checker {
     // Otherwise parallel pings could steal eachothers files due to invalid mtime.
     $check_time = 1.0;
     for ($time = microtime(TRUE); microtime(TRUE) - $time < $check_time && !file_exists($tmp); usleep(10000)) {}
-    
-    if (!file_exists($tmp)) {
-      $this->setStatus('warning', "File did not appear during $check_time sec.", [
+
+    // This forces the file mtime to be time().
+    if (!touch($tmp)) {
+      $this->setStatus('warning', 'Could not touch file.', [
         'file' => $tmp,
       ]);
       return;
     }
 
-    // This forces the file mtime to be time().
-    if (!touch($tmp)) {
-      $this->setStatus('warning', 'Could not touch file.', [
+    if (!file_exists($tmp)) {
+      $this->setStatus('warning', "File did not appear during $check_time sec nor after touch.", [
         'file' => $tmp,
       ]);
       return;

--- a/_ping.php
+++ b/_ping.php
@@ -1205,10 +1205,11 @@ class FsSchemeCleanupChecker extends Checker {
 
       // Do not clean up fresh files.
       // In the multicontainer environment parallel pings would kill each other.
-      if ($mtime < time() - 3600) {
+      if ($mtime > time() - 3600) {
+        error_log(sprintf('Should continue:  %s %d %d %d', $file, $mtime, time(), ($mtime > time() - 3600)));
         continue;
       }
-      error_log(sprintf('%s %d %d', $file, $mtime, time()));
+      error_log(sprintf('After continue %s %d %d %d', $file, $mtime, time(), ($mtime > time() - 3600) ));
       // @codingStandardsIgnoreLine PHPCS_SecurityAudit.BadFunctions.FilesystemFunctions.WarnFilesystem
       if (!unlink($file)) {
         $this->setStatus('error', 'Could not delete file in the public files directory.', [

--- a/_ping.php
+++ b/_ping.php
@@ -1069,6 +1069,27 @@ class FsSchemeCreateChecker extends Checker {
       ]);
       return;
     }
+    
+    for ($i = 0; $i < 10 && !file_exists($tmp); $i++) {
+      usleep(100000);
+    }
+    if (!file_exists($tmp)) {
+      $this->setStatus('error', 'File did not appear during 1 sec.', [
+        'path' => $path,
+      ]);
+      return;
+    }
+    
+    $mtime = filemtime($tmp);
+    $time = time();
+    if ($mtime < $time - 5) {
+         $this->setStatus('error', 'File mtime was unexpected.', [
+        'path' => $path,
+        'mtime' => $mtime,
+        'time' => $time,
+      ]);
+      return;
+    }
 
     $this->file = $tmp;
   }
@@ -1116,7 +1137,7 @@ class FsSchemeDeleteChecker extends Checker {
       $this->setStatus('disabled');
       return;
     }
-    sleep(1);
+    
     // @codingStandardsIgnoreLine PHPCS_SecurityAudit.BadFunctions.FilesystemFunctions.WarnFilesystem
     if (!unlink($this->file)) {
       $this->setStatus('error', 'Could not delete newly created file in the files directory.', [
@@ -1206,7 +1227,6 @@ class FsSchemeCleanupChecker extends Checker {
       // Do not clean up fresh files.
       // In the multicontainer environment parallel pings would kill each other.
       if ($mtime > time() - 3600) {
-        error_log(sprintf('Should continue:  %s %d %d %d', $file, $mtime, time(), ($mtime > time() - 3600)));
         continue;
       }
       error_log(sprintf('After continue %s %d %d %d', $file, $mtime, time(), ($mtime > time() - 3600) ));

--- a/_ping.php
+++ b/_ping.php
@@ -1075,7 +1075,7 @@ class FsSchemeCreateChecker extends Checker {
     }
     if (!file_exists($tmp)) {
       $this->setStatus('error', 'File did not appear during 1 sec.', [
-        'path' => $path,
+        'file' => $tmp,
       ]);
       return;
     }
@@ -1084,7 +1084,7 @@ class FsSchemeCreateChecker extends Checker {
     $time = time();
     if ($mtime < $time - 5) {
          $this->setStatus('error', 'File mtime was unexpected.', [
-        'path' => $path,
+        'file' => $tmp,
         'mtime' => $mtime,
         'time' => $time,
       ]);

--- a/_ping.php
+++ b/_ping.php
@@ -1269,7 +1269,6 @@ class FsSchemeCleanupChecker extends Checker {
       $this->setStatus('warning', 'Orphaned fs check files deleted.', [
         'removed_count' => $removed,
       ]);
-      return;
     }
   }
 

--- a/_ping.php
+++ b/_ping.php
@@ -1208,7 +1208,7 @@ class FsSchemeCleanupChecker extends Checker {
       if ($mtime < time() - 3600) {
         continue;
       }
-
+      error_log(sprintf('%s %d %d', $file, $mtime, time()));
       // @codingStandardsIgnoreLine PHPCS_SecurityAudit.BadFunctions.FilesystemFunctions.WarnFilesystem
       if (!unlink($file)) {
         $this->setStatus('error', 'Could not delete file in the public files directory.', [

--- a/_ping.php
+++ b/_ping.php
@@ -1070,16 +1070,22 @@ class FsSchemeCreateChecker extends Checker {
       return;
     }
     
+    for ($time = microtime(TRUE); microtime(TRUE) - $time < 1.0 && !file_exists($tmp); usleep(10000)) {}
+    
+    if (!file_exists($tmp)) {
+      $this->setStatus('error', 'File did not appear during 1 sec.', [
+        'file' => $tmp,
+      ]);
+      return;
+    }
+
     if (!touch($tmp)) {
-       $this->setStatus('error', 'Could not touch file.', [
+      $this->setStatus('error', 'Could not touch file.', [
         'file' => $tmp,
       ]);
       return;
     }
     
-    for ($i = 0; $i < 10 && !file_exists($tmp); $i++) {
-      usleep(100000);
-    }
     if (!file_exists($tmp)) {
       $this->setStatus('error', 'File did not appear during 1 sec.', [
         'file' => $tmp,

--- a/_ping.php
+++ b/_ping.php
@@ -1116,7 +1116,7 @@ class FsSchemeDeleteChecker extends Checker {
       $this->setStatus('disabled');
       return;
     }
-
+    sleep(1);
     // @codingStandardsIgnoreLine PHPCS_SecurityAudit.BadFunctions.FilesystemFunctions.WarnFilesystem
     if (!unlink($this->file)) {
       $this->setStatus('error', 'Could not delete newly created file in the files directory.', [

--- a/_ping.php
+++ b/_ping.php
@@ -1213,6 +1213,7 @@ class FsSchemeCleanupChecker extends Checker {
       if (!unlink($file)) {
         $this->setStatus('error', 'Could not delete file in the public files directory.', [
           'file' => $file,
+          'error' => error_get_last()['message'],
         ]);
         return;
       }

--- a/_ping.php
+++ b/_ping.php
@@ -1070,6 +1070,13 @@ class FsSchemeCreateChecker extends Checker {
       return;
     }
     
+    if (!touch($tmp)) {
+       $this->setStatus('error', 'Could not touch file.', [
+        'file' => $tmp,
+      ]);
+      return;
+    }
+    
     for ($i = 0; $i < 10 && !file_exists($tmp); $i++) {
       usleep(100000);
     }

--- a/tests/FsSchemeCleanupCheckerTest.php
+++ b/tests/FsSchemeCleanupCheckerTest.php
@@ -106,4 +106,28 @@ class FsSchemeCleanupCheckerTest extends TestCase {
     $this->assertEquals(['success', []], $status);
   }
 
+  /**
+   * @covers ::check2
+   */
+  public function testCheckMtime(): void {
+    // TODO
+    $this->assertEquals(TRUE, FALSE);
+  }
+
+  /**
+   * @covers ::check2
+   */
+  public function testCheckMtimeFresh(): void {
+    // TODO
+    $this->assertEquals(TRUE, FALSE);
+  }
+
+  /**
+   * @covers ::check2
+   */
+  public function testCheckMtimeOld(): void {
+    // TODO
+    $this->assertEquals(TRUE, FALSE);
+  }
+
 }


### PR DESCRIPTION
**The problem**
Ping fails when running in parallel containers.

**The cause**
They start to remove each other temporary test files.

**The goal**
Run pings safely in parallel.

**The solution**
Before removing write-test files, check the timestamp. Remove files that are older than 1h.

**Testing**
- Unit tests were not done due to a bad testing environment setup.
- Try this feature in both filesystems: object-store and on NFS-like systems.
- Hammer the ping
- Check logs