### PR TITLE
Feature/44 better handling for memcache

### DIFF
--- a/.lando/run
+++ b/.lando/run
@@ -10,7 +10,7 @@ export PATH="$PATH:/app/drupal/vendor/bin"
 cd "/app/drupal"
 
 set +e
-drush status bootstrap | grep -q Successful
+drush status | grep -q -e 'Drupal bootstrap *: *Successful'
 status="$?"
 set -e
 if [[ "$status" -ne 0 ]]; then

--- a/_ping.php
+++ b/_ping.php
@@ -151,7 +151,7 @@ TXT;
     $profiling_tbl = $this->profile->getTextTable(PHP_EOL);
     print <<<TXT
 
-<pre>
+<pre style="color:red">
 $buffered_output
 </pre>
 

--- a/_ping.php
+++ b/_ping.php
@@ -746,15 +746,18 @@ class MemcacheChecker extends Checker {
 
     if ($good_count > 0 && $bad_count > 0) {
       $this->setStatus('warning', 'Connection warnings.', ['warnings' => $msgs]);
+      \Drupal::logger('drupal_ping')->warning('Memcache connection warning. Warning messages: @warnings', ['@warnings' => json_encode($msgs)]);
       return;
     }
 
     if ($good_count < 1 && $bad_count > 0) {
       $this->setStatus('warning', 'Connection errors.', ['errors' => $msgs]);
+      \Drupal::logger('drupal_ping')->error('Memcache connection error. Error messages: @errors', ['@errors' => json_encode($msgs)]);
       return;
     }
 
-    $this->setStatus('error', 'Internal error.');
+    \Drupal::logger('drupal_ping')->error('Memcache internal error.');
+    $this->setStatus('warning', 'Internal error.');
   }
 
 }

--- a/_ping.php
+++ b/_ping.php
@@ -52,6 +52,10 @@ class App {
      * Setup
      */
 
+    // Start output buffering as any PHP notice would return 503 error code
+    // if printed before setting headers.
+    ob_start();
+
     // Start profiling as early as possible.
     $this->profile = new Profile();
     $this->status = new Status();
@@ -111,6 +115,11 @@ class App {
     $payloads = $this->status2logs($payloads, 'error');
     $this->logErrors($payloads, 'error');
 
+    // Stop buffering before setting headers. After that it doesn't matter
+    // if there's any output as script is not going to give 503 error code
+    // anymore.
+    $buffered_output = ob_get_clean();
+
     if (!empty($payloads)) {
       $code = 500;
       $msg = 'INTERNAL ERROR';
@@ -141,6 +150,10 @@ TXT;
     $status_tbl = $this->status->getTextTable(PHP_EOL);
     $profiling_tbl = $this->profile->getTextTable(PHP_EOL);
     print <<<TXT
+
+<pre>
+$buffered_output
+</pre>
 
 <pre>
 $status_tbl

--- a/_ping.php
+++ b/_ping.php
@@ -709,7 +709,7 @@ class MemcacheChecker extends Checker {
 
       // We are not relying on Memcache or Memcached classes.
       // For speed and simplicity we use just basic networking.
-      $socket = fsockopen($s['host'], $s['port'], $errno, $errstr, 1);
+      $socket = @fsockopen($s['host'], $s['port'], $errno, $errstr, 1);
       if (!empty($errstr)) {
         $msgs[] = [
           'host' => $s['host'],
@@ -750,7 +750,7 @@ class MemcacheChecker extends Checker {
     }
 
     if ($good_count < 1 && $bad_count > 0) {
-      $this->setStatus('error', 'Connection errors.', ['errors' => $msgs]);
+      $this->setStatus('warning', 'Connection errors.', ['errors' => $msgs]);
       return;
     }
 

--- a/_ping.php
+++ b/_ping.php
@@ -101,15 +101,15 @@ class App {
 
     $slows = $this->profile->getByDuration(1000, NULL);
     $payloads = $this->profile2logs($slows, 'slow');
-    $this->logErrors($payloads);
+    $this->logErrors($payloads, 'notice');
 
     $payloads = $this->status->getBySeverity('warning');
     $payloads = $this->status2logs($payloads, 'warning');
-    $this->logErrors($payloads);
+    $this->logErrors($payloads, 'warning');
 
     $payloads = $this->status->getBySeverity('error');
     $payloads = $this->status2logs($payloads, 'error');
-    $this->logErrors($payloads);
+    $this->logErrors($payloads, 'error');
 
     if (!empty($payloads)) {
       $code = 500;
@@ -279,14 +279,17 @@ TXT;
    * Log errors according to the environment.
    *
    * We recognize following envs:
+   * - drupal -> Drupal logger.
    * - silta -> stderr.
    * - lando -> stderr.
    * - the rest -> syslog().
    *
    * @param array $payloads
    *   Array of payload arrays, containing error message and additional info.
+   * @param string $severity
+   *   The severity of Drupal logger (method name).
    */
-  public function logErrors(array $payloads): void {
+  public function logErrors(array $payloads, string $severity): void {
 
     if (!empty(getenv('TESTING'))) {
       $logger = function (string $msg) {
@@ -297,20 +300,30 @@ TXT;
         $_logs[] = $msg;
       };
     }
+    elseif (method_exists('\Drupal', 'logger')) {
+      $logger = function (string $msg) use ($severity) {
+        try {
+          // Replace curly braces with double parentheses because Drupal logging
+          // is unable to handle JSON.
+          $msg = str_replace(['{', '}'], ['((', '))'], $msg);
+          \Drupal::logger('drupal_ping')->{$severity}($msg);
+        } catch(\Exception $e) { }
+      };
+    }
     elseif (!empty(getenv('SILTA_CLUSTER')) || !empty(getenv('LANDO'))) {
       $logger = function (string $msg) {
-        error_log($msg);
+        error_log("ping: $msg");
       };
     }
     else {
       $logger = function (string $msg) {
-        syslog(LOG_ERR | LOG_LOCAL6, $msg);
+        syslog(LOG_ERR | LOG_LOCAL6, "ping: $msg");
       };
     }
 
     foreach ($payloads as $payload) {
       $payload = json_encode($payload);
-      $logger("ping: $payload");
+      $logger($payload);
     }
   }
 
@@ -746,18 +759,15 @@ class MemcacheChecker extends Checker {
 
     if ($good_count > 0 && $bad_count > 0) {
       $this->setStatus('warning', 'Connection warnings.', ['warnings' => $msgs]);
-      \Drupal::logger('drupal_ping')->warning('Memcache connection warning. Warning messages: @warnings', ['@warnings' => json_encode($msgs)]);
       return;
     }
 
     if ($good_count < 1 && $bad_count > 0) {
       $this->setStatus('warning', 'Connection errors.', ['errors' => $msgs]);
-      \Drupal::logger('drupal_ping')->error('Memcache connection error. Error messages: @errors', ['@errors' => json_encode($msgs)]);
       return;
     }
 
-    \Drupal::logger('drupal_ping')->error('Memcache internal error.');
-    $this->setStatus('warning', 'Internal error.');
+    $this->setStatus('error', 'Internal error.');
   }
 
 }

--- a/_ping.php
+++ b/_ping.php
@@ -320,7 +320,9 @@ TXT;
           // is unable to handle JSON.
           $msg = str_replace(['{', '}'], ['((', '))'], $msg);
           \Drupal::logger('drupal_ping')->{$severity}($msg);
-        } catch(\Exception $e) { }
+        }
+        catch (\Exception $e) {
+        }
       };
     }
     elseif (!empty(getenv('SILTA_CLUSTER')) || !empty(getenv('LANDO'))) {

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -41,10 +41,10 @@ class AppTest extends TestCase {
     $a->logErrors([
       ['check1' => 'msg1'],
       ['check2' => 'msg2'],
-    ]);
+    ], 'notice');
     $expected = [
-      'ping: {"check1":"msg1"}',
-      'ping: {"check2":"msg2"}',
+      '{"check1":"msg1"}',
+      '{"check2":"msg2"}',
     ];
     $this->assertEquals($expected, $_logs);
   }

--- a/tests/MemcacheCheckerTest.php
+++ b/tests/MemcacheCheckerTest.php
@@ -108,7 +108,7 @@ class MemcacheCheckerTest extends TestCase {
         'error' => 'Connection refused',
       ]],
     ];
-    $this->assertEquals(['error', $data], $status);
+    $this->assertEquals(['warning', $data], $status);
   }
 
   /**
@@ -133,7 +133,7 @@ class MemcacheCheckerTest extends TestCase {
         'error' => 'Cannot assign requested address',
       ]],
     ];
-    $this->assertEquals(['error', $data], $status);
+    $this->assertEquals(['warning', $data], $status);
   }
 
   /**
@@ -227,7 +227,7 @@ class MemcacheCheckerTest extends TestCase {
         ],
       ],
     ];
-    $this->assertEquals(['error', $data], $status);
+    $this->assertEquals(['warning', $data], $status);
   }
 
 }


### PR DESCRIPTION
## Description

We need to check if Memcache is working and send alerts to Slack channel if there are problems. Ping seemed like a good candidate so for this to work we need to send logs to Sumo and the easiest would be to send them via Drupal logs.

This PR is about adding support for sending logs via Drupal logger if it exists and also adding some fixes like outputting PHP notices after headers have been sent (otherwise in our case ping gave 503 error code) and also coloring those notices red.

## Screenshots

/_ping.php?debug=1
![image](https://github.com/wunderio/drupal-ping/assets/492375/0dd410ae-293a-47c8-9dd3-a1068cdd9fe9)

/_ping.php?debug=1
![2023-06-09_11-01](https://github.com/wunderio/drupal-ping/assets/492375/cb77eec4-a4ad-4b1a-8da0-0590a1bbccf6)

## Testing notes

It's maybe hard to test if you don't have Memcache installed but in our case in settings.php we renamed the Memcache host to something that would not exist in "$settings['memcache']['servers']"