### PR TITLE
hotfix: Improve ping installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ It is not suitable for subsystem health-checks for things like container or load
 }
 ```
 
+Note: The `web` path should be replaced to the actual directory name that is used by the webserver to serve Drupal. Depending on setup it may be, for example, `docroot`. Since the `dropin` plugin physically moves the '_ping.php', you may need re-install `wunderio/drupal-ping` package if you accidentally specified wrong destination path during first package install.
+
 2. Then install the composer package as usual with:
 
 ```


### PR DESCRIPTION
Slightly improved the instructions as to the path of the Drupal installation that needs to be specified. Also, experienced a case where after changing the path to correct one, the '_ping.php' was already moved out of the vendor package thus during the second run `_ping.php` could not be moved since it did not exist (not sure of the cause, maybe I stashed it after initial install)

One way to solve that edge case may be specifying the droping plugin to utlize 'copy' instead of 'move'? Seems like might be a better option?

    "config": {
        "dropin-installer": "copy",
    }
